### PR TITLE
Update to Ludusavi 0.27.0's app ID

### DIFF
--- a/scripts/winesapos-install.sh
+++ b/scripts/winesapos-install.sh
@@ -1016,7 +1016,7 @@ if [[ "${WINESAPOS_INSTALL_GAMING_TOOLS}" == "true" ]]; then
     # GOverlay.
     cp "${WINESAPOS_INSTALL_DIR}"/usr/share/applications/io.github.benjamimgois.goverlay.desktop "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/
     # Ludusavi.
-    cp "${WINESAPOS_INSTALL_DIR}"/usr/share/applications/com.github.mtkennerly.ludusavi.desktop "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/
+    cp "${WINESAPOS_INSTALL_DIR}"/usr/share/applications/com.mtkennerly.ludusavi.desktop "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/
     # Nexus Mods app.
     cp "${WINESAPOS_INSTALL_DIR}"/usr/share/applications/com.nexusmods.app.desktop "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/
     # Oversteer.

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -748,7 +748,7 @@ gaming_auto() {
     "${qdbus_cmd}" "${kdialog_dbus}" /ProgressDialog Set org.kde.kdialog.ProgressDialog value 6
     # Ludusavi.
     "${CMD_AUR_INSTALL[@]}" ludusavi
-    cp /usr/share/applications/com.github.mtkennerly.ludusavi.desktop /home/"${USER}"/Desktop/
+    cp /usr/share/applications/com.mtkennerly.ludusavi.desktop /home/"${USER}"/Desktop/
     "${qdbus_cmd}" "${kdialog_dbus}" /ProgressDialog Set org.kde.kdialog.ProgressDialog value 7
     # Lutris.
     sudo "${CMD_FLATPAK_INSTALL[@]}" net.lutris.Lutris

--- a/scripts/winesapos-tests.sh
+++ b/scripts/winesapos-tests.sh
@@ -877,7 +877,7 @@ if [[ "${WINESAPOS_INSTALL_GAMING_TOOLS}" == "true" ]]; then
     for i in \
       "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/decky_installer.desktop \
       "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/io.github.benjamimgois.goverlay.desktop \
-      "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/com.github.mtkennerly.ludusavi.desktop \
+      "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/com.mtkennerly.ludusavi.desktop \
       "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/com.nexusmods.app.desktop \
       "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/NonSteamLaunchers.desktop \
       "${WINESAPOS_INSTALL_DIR}"/home/"${WINESAPOS_USER_NAME}"/Desktop/polychromatic.desktop \


### PR DESCRIPTION
Ludusavi v0.27.0 reports its app ID as `com.mtkennerly.ludusavi` instead of just `ludusavi` to be more conformant. Note that this is intentionally different from the Flatpak ID (`com.github.mtkennerly.ludusavi`), which I think is too late to change now.

The AUR package has already been updated to use `com.mtkennerly.ludusavi` as well: https://aur.archlinux.org/cgit/aur.git/commit/?h=ludusavi&id=74d6d18c590e70d3cd210ef3ab92a4f9ad495cf7

More context:

* https://github.com/mtkennerly/ludusavi/pull/417
* https://github.com/mtkennerly/ludusavi/commit/0625c60b5ddc348bed8f12edea7ca17160056a51
